### PR TITLE
Finish type-hinting for all scripts/tests

### DIFF
--- a/scripts/00-fetch-inspection-list.py
+++ b/scripts/00-fetch-inspection-list.py
@@ -1,5 +1,6 @@
 import csv
 import string
+import typing
 from itertools import chain
 from multiprocessing import Pool
 from pathlib import Path
@@ -13,7 +14,9 @@ from lib.aphis import (
 )
 
 
-def iter_char(init_criteria):
+def iter_char(
+    init_criteria: dict[str, typing.Any]
+) -> typing.Generator[dict[str, str], None, None]:
     base = init_criteria.get("customerName", "")
 
     chars = list(string.ascii_lowercase) + list(string.digits) + list(" ,.&-")
@@ -33,7 +36,7 @@ def iter_char(init_criteria):
             yield from deduplicate(iter_char(new_criteria))
 
 
-def fetch_for_letter(letter):
+def fetch_for_letter(letter: str) -> None:
     dest = Path(f"data/fetched/inspections-by-letter/{letter}.csv")
     if dest.exists():
         return
@@ -42,7 +45,7 @@ def fetch_for_letter(letter):
     write_results(results, dest)
 
 
-def main():
+def main() -> None:
     with Pool(processes=6) as pool:
         pool.map(fetch_for_letter, string.ascii_lowercase)
 

--- a/scripts/01-refresh-inspection-list.py
+++ b/scripts/01-refresh-inspection-list.py
@@ -3,7 +3,7 @@ import csv
 from lib.aphis import add_hash_ids, deduplicate, fetch, iter_fetch_all, write_results
 
 
-def main():
+def main() -> None:
     search_total = fetch(0, {})["totalCount"]
     with open("data/fetched/inspections-search-total.txt", "w") as f:
         f.write(str(search_total))

--- a/scripts/02-download-inspection-pdfs.py
+++ b/scripts/02-download-inspection-pdfs.py
@@ -9,7 +9,7 @@ from retry import retry
 
 
 @retry(tries=10, delay=30)
-def fetch(link: str, timeout: int = 60):
+def fetch(link: str, timeout: int = 60) -> bytes:
     """Request the provided URL and return the content."""
     res = requests.get(link, timeout=timeout)
     assert res.ok
@@ -17,7 +17,7 @@ def fetch(link: str, timeout: int = 60):
     return res.content
 
 
-def main():
+def main() -> None:
     """Download inspection PDFs."""
     with open("data/fetched/inspections.csv") as f:
         reports = list(csv.DictReader(f))

--- a/scripts/04-upload-inspection-pdfs.py
+++ b/scripts/04-upload-inspection-pdfs.py
@@ -17,7 +17,7 @@ CACHE_DIR = ROOT_DIR / "data" / "doccloud" / "inspections"
 PDF_DIR = ROOT_DIR / "pdfs" / "inspections"
 
 
-def main():
+def main() -> None:
     """Upload all local PDFs not yet posted to DocumentCloud."""
 
     # Get everything that's been downloaded
@@ -56,7 +56,7 @@ def main():
         time.sleep(0.25)
 
 
-def get_documentcloud_client():
+def get_documentcloud_client() -> DocumentCloud:
     """Initialize and return a DocumentCloud client that's ready to use."""
     return DocumentCloud(
         os.getenv("DOCUMENTCLOUD_USER"), os.getenv("DOCUMENTCLOUD_PASSWORD")

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -58,13 +58,14 @@ RESULTS_EXAMPLE = [
 ]
 
 
-def test_hash_id_from_url():
+def test_hash_id_from_url() -> None:
     """Test the hash_id_from_url utility."""
-    hash_id = aphis.hash_id_from_url(RESULTS_EXAMPLE[0]["reportLink"])
+    link = str(RESULTS_EXAMPLE[0]["reportLink"])
+    hash_id = aphis.hash_id_from_url(link)
     assert hash_id == "70c3bd51cf5e10cb"
 
 
-def test_add_hash_ids():
+def test_add_hash_ids() -> None:
     """Test the add_hash_ids utility."""
     added = aphis.add_hash_ids(RESULTS_EXAMPLE)
 
@@ -77,7 +78,7 @@ def test_add_hash_ids():
     aphis.add_hash_ids(added)
 
 
-def test_get_sort_key():
+def test_get_sort_key() -> None:
     """Test the get_sort_key utility."""
     key = aphis.get_sort_key(RESULTS_EXAMPLE[0])
     assert key == (
@@ -89,7 +90,7 @@ def test_get_sort_key():
     )
 
 
-def test_deduplicate():
+def test_deduplicate() -> None:
     """Test the deduplicate utility."""
     d = aphis.deduplicate(RESULTS_EXAMPLE, sort=False)
     # Last item in array is intentionally a dupe


### PR DESCRIPTION
Per #19. Tested via `mypy scripts tests --strict --ignore-missing-imports`; I can update the Makefile to use that (adding `--strict`) when/if #26 is merged.